### PR TITLE
Follow release-21.11, use nixFlakes alias (nix 2.4)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,10 +14,12 @@ steps:
       CACHIX_AUTH_TOKEN:
         from_secret: CACHIX_AUTH_TOKEN
     commands:
+      - "nix-channel --add https://nixos.org/channels/nixos-21.11 nixpkgs"
+      - "nix-channel --update"
       - "nix-env -iA nixpkgs.nixFlakes"
       - "echo 'experimental-features = nix-command flakes ca-references' >> /etc/nix/nix.conf"
       - "echo 'max-jobs = auto' >> /etc/nix/nix.conf"
-      - "nix profile install github:NixOS/nixpkgs/nixos-unstable-small#cachix github:NixOS/nixpkgs/nixos-unstable-small#git"
+      - "nix profile install github:NixOS/nixpkgs/nixos-21.11-small#cachix github:NixOS/nixpkgs/nixos-21.11-small#git"
       - "cachix use dram"
       - "cachix watch-exec dram -- nix flake check -vL"
 
@@ -37,9 +39,11 @@ steps:
       CACHIX_AUTH_TOKEN:
         from_secret: CACHIX_AUTH_TOKEN
     commands:
+      - "nix-channel --add https://nixos.org/channels/nixos-21.11 nixpkgs"
+      - "nix-channel --update"
       - "nix-env -iA nixpkgs.nixFlakes"
       - "echo 'experimental-features = nix-command flakes ca-references' >> /etc/nix/nix.conf"
       - "echo 'max-jobs = auto' >> /etc/nix/nix.conf"
-      - "nix profile install github:NixOS/nixpkgs/nixos-unstable-small#cachix github:NixOS/nixpkgs/nixos-unstable-small#git"
+      - "nix profile install github:NixOS/nixpkgs/nixos-21.11-small#cachix github:NixOS/nixpkgs/nixos-21.11-small#git"
       - "cachix use dram"
       - "cachix watch-exec dram -- nix flake check -vL"

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1639347265,
-        "narHash": "sha256-q5feWoC64+h6T6J89o2HJJ8DOnB/4vwMODBlZIgeIlA=",
+        "lastModified": 1639399671,
+        "narHash": "sha256-KT+YqqPZsdzKNE4T8okeH8lV+a0vtFxD4w+P2CEZC40=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0bf5f888d377dd2f36d90340df6dc9f035aaada",
+        "rev": "c95b2e99529891b1d52e065c34dd50c136151bcb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1634172192,
-        "narHash": "sha256-FBF4U/T+bMg4sEyT/zkgasvVquGzgdAf4y8uCosKMmo=",
+        "lastModified": 1637595801,
+        "narHash": "sha256-LkIMwVFKCuEqidaUdg8uxwpESAXjsPo4oCz3eJ7RaRw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2cf9db0e3d45b9d00f16f2836cb1297bcadc475e",
+        "rev": "263ef4cc4146c9fab808085487438c625d4426a9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
         "type": "github"
       },
       "original": {
@@ -17,16 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637595801,
-        "narHash": "sha256-LkIMwVFKCuEqidaUdg8uxwpESAXjsPo4oCz3eJ7RaRw=",
+        "lastModified": 1638231180,
+        "narHash": "sha256-H1F1kqKBn57RS8eTOyc3YjyFi9nxSXdrnt5KLr3t3/8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "263ef4cc4146c9fab808085487438c625d4426a9",
+        "rev": "8906ff19716fa362fb97f2398717ed99c938645a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "release-21.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
         nix-nar-listing =
           final.haskellPackages.callPackage ./nix-nar-listing {};
 
-        nix-dram = final.nixUnstable.overrideAttrs (old: {
+        nix-dram = final.nixStable.overrideAttrs (old: {
           name = "nix-dram-" + old.version;
           patches = (old.patches or []) ++ [
             ./nix-patches/nix-flake-default.patch
@@ -62,7 +62,7 @@
           ];
         });
 
-        nix-dram-progress = final.nixUnstable.overrideAttrs (old: {
+        nix-dram-progress = final.nixStable.overrideAttrs (old: {
           name = "nix-dram-" + old.version;
           patches = (old.patches or []) ++ [
             ./nix-patches/nix-flake-default.patch

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
         nix-nar-listing =
           final.haskellPackages.callPackage ./nix-nar-listing {};
 
-        nix-dram = final.nixStable.overrideAttrs (old: {
+        nix-dram = final.nixFlakes.overrideAttrs (old: {
           name = "nix-dram-" + old.version;
           patches = (old.patches or []) ++ [
             ./nix-patches/nix-flake-default.patch
@@ -62,7 +62,7 @@
           ];
         });
 
-        nix-dram-progress = final.nixStable.overrideAttrs (old: {
+        nix-dram-progress = final.nixFlakes.overrideAttrs (old: {
           name = "nix-dram-" + old.version;
           patches = (old.patches or []) ++ [
             ./nix-patches/nix-flake-default.patch

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Nix with a modified frontend, by dramforever";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-21.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   nixConfig = {


### PR DESCRIPTION
- follow the fresh `release-21.11` branch
- `nix` [2.4 is pinned](https://github.com/NixOS/nixpkgs/blob/release-21.11/pkgs/top-level/aliases.nix#L603) to the `nixFlakes` alias in `release-21.11`, let's use it.
- update inputs
