### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1647297614,
-        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
+        "lastModified": 1651007983,
+        "narHash": "sha256-GNay7yDPtLcRcKCNHldug85AhAvBpTtPEJWSSDYBw8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
+        "rev": "e10da1c7f542515b609f8dfbcf788f3d85b14936",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
There's a build failure after this change, don't know what needs to be done regarding the dependencies to fix this:
```
nix-nar-listing> Using Parsec parser
nix-nar-listing> Configuring nix-nar-listing-0.1.0.0...
nix-nar-listing> Setup: Encountered missing or private dependencies:
nix-nar-listing> base >=4.14.1.0 && <4.15
error: builder for '/nix/store/sxwybpsjsnas4pzyrwxw2nf8fqph3rhw-nix-nar-listing-0.1.0.0.drv' failed with exit code 1;
       last 10 log lines:
       > [1 of 1] Compiling Main             ( Setup.hs, /build/Main.o )
       > Linking Setup ...
       > configuring
       > configureFlags: --verbose --prefix=/nix/store/1v6xcf1769xhp9lhj0ahd8jj417rcvfj-nix-nar-listing-0.1.0.0 --libdir=$prefix/lib/$compiler --libsubdir=$abi/$libname --docdir=/nix/store/ar3az98rbykcgiz8bc12cz3dv8q1pm4b-nix-nar-listing-0.1.0.0-doc/share/doc/nix-nar-listing-0.1.0.0 --with-gcc=gcc --package-db=/build/package.conf.d --ghc-options=-j8 +RTS -A64M -RTS --disable-split-objs --enable-library-profiling --profiling-detail=exported-functions --disable-profiling --enable-shared --disable-coverage --enable-static --disable-executable-dynamic --enable-tests --disable-benchmarks --enable-library-vanilla --disable-library-for-ghci --ghc-option=-split-sections --ghc-options=-haddock --extra-lib-dirs=/nix/store/clkdigybx5w29rjxnwnsk76q49gb12k7-ncurses-6.3/lib --extra-lib-dirs=/nix/store/gm6q7jmajjmnwd29wgbq2jm3x37vsw3h-libffi-3.4.2/lib --extra-lib-dirs=/nix/store/qxrvrhlfaislinykki6qy6nqd4wv8mdp-gmp-with-cxx-6.2.1/lib
       > Using Parsec parser
       > Configuring nix-nar-listing-0.1.0.0...
       >
       > Setup: Encountered missing or private dependencies:
       > base >=4.14.1.0 && <4.15
       >
       For full logs, run 'nix log /nix/store/sxwybpsjsnas4pzyrwxw2nf8fqph3rhw-nix-nar-listing-0.1.0.0.drv'.
error: build of '/nix/store/3pkx4qygnay53snnmlzgjqfw9ikgh2y6-nix-search.drv', '/nix/store/911jjgmpc24w6c3jdgq6790q3k3ysdws-nix-search-pretty-0.1.0.0.drv', '/nix/store/sxwybpsjsnas4pzyrwxw2nf8fqph3rhw-nix-nar-listing-0.1.0.0.drv' failed
```