### PR TITLE
WIP: Rebase patches for upstream changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651558728,
-        "narHash": "sha256-8HzyRnWlgZluUrVFNOfZAOlA1fghpOSezXvxhalGMUo=",
+        "lastModified": 1651726670,
+        "narHash": "sha256-dSGdzB49SEvdOJvrQWfQYkAefewXraHIV08Vz6iDXWQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbe587c735b734405f56803e267820ee1559e6c1",
+        "rev": "c777cdf5c564015d5f63b09cc93bef4178b19b01",
         "type": "github"
       },
       "original": {

--- a/nix-patches/nix-flake-default.patch
+++ b/nix-patches/nix-flake-default.patch
@@ -92,13 +92,13 @@ index 55a5e91e9..ffd3087b3 100644
              }
  
              try {
--                auto [flakeRef, fragment] = parseFlakeRefWithFragment(s, absPath("."));
+-                auto [flakeRef, fragment, outputsSpec] = parseFlakeRefWithFragmentAndOutputsSpec(s, absPath("."));
 +                bool isAttrPath = std::regex_match(s, attrPathRegex);
 +
-+                auto [flakeRef, fragment] =
++                auto [flakeRef, fragment, outputsSpec] =
 +                    isAttrPath
-+                    ? std::make_pair(parseFlakeRef(installablesSettings.getDefaultFlake(s), {}), s)
-+                    : parseFlakeRefWithFragment(s, absPath("."));
++                    ? std::make_tuple(parseFlakeRef(installablesSettings.getDefaultFlake(s), {}), parseOutputsSpec(s))
++                    : parseFlakeRefWithFragmentAndOutputsSpec(s, absPath("."));
 +
                  result.push_back(std::make_shared<InstallableFlake>(
                          this,


### PR DESCRIPTION
Tried to adapt the installables.cc patch for upstream changes.

The build fails and I've got no clue how to fix this error:

```
src/libcmd/[installables.cc](http://installables.cc/): In member function 'std::vector<std::shared_ptr<nix::Installable> > nix::SourceExprCommand::parseInstallables(nix::ref<nix::Store>, std::vector<std::__cxx11::basic_string<char> >)':
src/libcmd/[installables.cc:828](http://installables.cc:828/):21: error: operands to '?:' have different types 'std::tuple<nix::FlakeRef, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::variant<nix::DefaultOutputs, nix::AllOutputs, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >' and 'std::tuple<nix::FlakeRef, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::variant<nix::DefaultOutputs, nix::AllOutputs, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >'
  827 |                     isAttrPath
      |                     ~~~~~~~~~~
  828 |                     ? std::make_tuple(parseFlakeRef(installablesSettings.getDefaultFlake(s), {}), parseOutputsSpec(s))
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  829 |                     : parseFlakeRefWithFragmentAndOutputsSpec(s, absPath("."));
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Basically the difference in types is one `std::pair` from what I can tell:
```
std::tuple<nix::FlakeRef, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::variant<nix::DefaultOutputs, nix::AllOutputs, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >
std::tuple<nix::FlakeRef, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::variant<nix::DefaultOutputs, nix::AllOutputs, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >
```

Feedback and help welcome : ) 